### PR TITLE
Fixed form helper for Rails 3

### DIFF
--- a/jquery_datepicker.gemspec
+++ b/jquery_datepicker.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = "View helper that allows to select dates from a calendar (using jQuery Ui plugin)"
   s.email = "albert.pastor@gmail.com"
   s.extra_rdoc_files = ["README.rdoc", "lib/app/helpers/datepicker_helper.rb", "lib/app/helpers/form_helper.rb", "lib/jquery_datepicker.rb"]
-  s.files = ["Manifest", "README.rdoc", "Rakefile", "init.rb", "lib/app/helpers/datepicker_helper.rb", "lib/app/helpers/form_helper.rb", "lib/jquery_datepicker.rb", "jquery_datepicker.gemspec"]
+  s.files = ["README.rdoc", "Rakefile", "init.rb", "lib/app/helpers/datepicker_helper.rb", "lib/app/helpers/form_helper.rb", "lib/jquery_datepicker.rb", "jquery_datepicker.gemspec"]
   s.homepage = "http://github.com/albertopq/jquery_datepicker"
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Jquery_datepicker", "--main", "README.rdoc"]
   s.require_paths = ["lib"]

--- a/lib/app/helpers/form_helper.rb
+++ b/lib/app/helpers/form_helper.rb
@@ -4,7 +4,8 @@ module FormHelper
   def datepicker(att)
     model = self.object_name
     html = self.text_field att
-    html += '<script type="text/javascript">jQuery(document).ready(function(){$("#'+model+'_'+att.to_s+'").datepicker()});</script>'
+    tag = '<script type="text/javascript">jQuery(document).ready(function(){$("#'+model+'_'+att.to_s+'").datepicker()});</script>'
+    html << tag.html_safe
     return html
   end
   


### PR DESCRIPTION
The form helper didn't use html_safe and so was rendered in escaped text.
This code needs probably a check to work both on Rails 2 and 3, I only tested it with 3.
