### PR TITLE
Fixes ERROR:  While executing gem ... (Gem::InvalidSpecificationException

### DIFF
--- a/jquery_datepicker.gemspec
+++ b/jquery_datepicker.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = "View helper that allows to select dates from a calendar (using jQuery Ui plugin)"
   s.email = "albert.pastor@gmail.com"
   s.extra_rdoc_files = ["README.rdoc", "lib/app/helpers/datepicker_helper.rb", "lib/app/helpers/form_helper.rb", "lib/jquery_datepicker.rb"]
-  s.files = ["Manifest", "README.rdoc", "Rakefile", "init.rb", "lib/app/helpers/datepicker_helper.rb", "lib/app/helpers/form_helper.rb", "lib/jquery_datepicker.rb", "jquery_datepicker.gemspec"]
+  s.files = ["README.rdoc", "Rakefile", "init.rb", "lib/app/helpers/datepicker_helper.rb", "lib/app/helpers/form_helper.rb", "lib/jquery_datepicker.rb", "jquery_datepicker.gemspec"]
   s.homepage = "http://github.com/albertopq/jquery_datepicker"
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Jquery_datepicker", "--main", "README.rdoc"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
Fixes ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["Manifest"] are not files
When you removed the Manifest file you forgot to edit the gemspec file breaking gem builds
