### PR TITLE
Update installation instructions to work on Rails 3.1

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -12,6 +12,11 @@ This simple gem allows you to add a date picker field into your views.
 
     rails generate jquery:install --ui
 
+   In Rails 3.1 when using the asset pipeline, this generator is deprecated, so you'll need to add at line to your app/assets/javascripts/application.js:
+
+    //= require jquery-ui
+
+   And then install the jquery-ui CSS.  You can get a bundle to match your site from {ThemeRoller}[http://jqueryui.com/themeroller/].  From your theme bundle, extract the CSS directory and place it somewhere under app/assets/stylesheets/.
 
 3. Insert into your Gemfile:
 


### PR DESCRIPTION
The jquery generator is deprecated in Rails 3.1.  So the given installation instructions did not work for me.

I've updated the instructions to capture the extra steps I went through.  Maybe someday it can be streamlined, but at least it would be nice to have the documentation updated.
