### PR TITLE
Handle non-US Date formats

### DIFF
--- a/lib/app/helpers/form_helper.rb
+++ b/lib/app/helpers/form_helper.rb
@@ -53,7 +53,7 @@ class JqueryDatepicker::InstanceTag < ActionView::Helpers::InstanceTag
   
   def format_date(tb_formatted, format)
     new_format = translate_format(format)
-    Date.parse(tb_formatted).strftime(new_format)
+    Date.strptime(tb_formatted, new_format)
   end
 
   # Method that translates the datepicker date formats, defined in (http://docs.jquery.com/UI/Datepicker/formatDate)


### PR DESCRIPTION
Stop using Date.parse. it does not support d/m/Y format on Ruby 1.8.x, and it does not support m/d/Y format on Ruby 1.9.

Cf.

  https://bugs.ruby-lang.org/issues/634
