### PR TITLE
Respect :id option when generating javascript_tag

### DIFF
--- a/lib/app/helpers/form_helper.rb
+++ b/lib/app/helpers/form_helper.rb
@@ -7,13 +7,12 @@ module JqueryDatepicker
 
     # Mehtod that generates datepicker input field inside a form
     def datepicker(object_name, method, options = {}, timepicker = false)
-      options = options.stringify_keys
       input_tag =  JqueryDatepicker::InstanceTag.new(object_name, method, self, options.delete(:object))
       dp_options, tf_options =  input_tag.split_options(options)
       tf_options[:value] = input_tag.format_date(tf_options[:value], String.new(dp_options[:dateFormat])) if  tf_options[:value] && !tf_options[:value].empty? && dp_options.has_key?(:dateFormat)
       html = input_tag.to_input_field_tag("text", tf_options)
       method = timepicker ? "datetimepicker" : "datepicker"
-      html += javascript_tag("jQuery(document).ready(function(){jQuery('##{input_tag.get_name_and_id(tf_options)["id"]}').#{method}(#{dp_options.to_json})});")
+      html += javascript_tag("jQuery(document).ready(function(){jQuery('##{input_tag.get_name_and_id(tf_options.stringify_keys)["id"]}').#{method}(#{dp_options.to_json})});")
       html.html_safe
     end
     

--- a/lib/app/helpers/form_helper.rb
+++ b/lib/app/helpers/form_helper.rb
@@ -7,12 +7,13 @@ module JqueryDatepicker
 
     # Mehtod that generates datepicker input field inside a form
     def datepicker(object_name, method, options = {}, timepicker = false)
+      options = options.stringify_keys
       input_tag =  JqueryDatepicker::InstanceTag.new(object_name, method, self, options.delete(:object))
       dp_options, tf_options =  input_tag.split_options(options)
       tf_options[:value] = input_tag.format_date(tf_options[:value], String.new(dp_options[:dateFormat])) if  tf_options[:value] && !tf_options[:value].empty? && dp_options.has_key?(:dateFormat)
       html = input_tag.to_input_field_tag("text", tf_options)
       method = timepicker ? "datetimepicker" : "datepicker"
-      html += javascript_tag("jQuery(document).ready(function(){jQuery('##{input_tag.get_name_and_id["id"]}').#{method}(#{dp_options.to_json})});")
+      html += javascript_tag("jQuery(document).ready(function(){jQuery('##{input_tag.get_name_and_id(tf_options)["id"]}').#{method}(#{dp_options.to_json})});")
       html.html_safe
     end
     

--- a/spec/jquery_datepicker_spec.rb
+++ b/spec/jquery_datepicker_spec.rb
@@ -7,8 +7,8 @@ require 'date'
 ActionView::Base.send(:include, JqueryDatepicker::DatepickerHelper)
 ActionView::Helpers::FormBuilder.send(:include,JqueryDatepicker::FormBuilder)
 
-current_value = Time.now
-current_value_date = Date.current
+current_value = Time.now.utc
+current_value_date = current_value.to_date
 
 describe JqueryDatepicker do
 
@@ -26,6 +26,10 @@ describe JqueryDatepicker do
 
     let :valid_response_javascript do
       "<script type=\"text/javascript\">\n//<![CDATA[\njQuery(document).ready(function(){jQuery('#foo_att1').datepicker({})});\n//]]>\n</script>"
+    end
+
+    let :valid_response_javascript_with_tf_options do
+      "<script type=\"text/javascript\">\n//<![CDATA[\njQuery(document).ready(function(){jQuery('#custom_id').datepicker({})});\n//]]>\n</script>"
     end
 
     let :valid_response_javascript_datetime do
@@ -57,7 +61,13 @@ describe JqueryDatepicker do
           <%= datepicker_input(:foo, :att1, :tabindex => 70) %>
         EOTEMPLATE
     end
-    
+   
+    let :datepicker_input_tf_options_id_and_name_template do
+        <<-EOTEMPLATE
+          <%= datepicker_input(:foo, :att1, :id => "custom_id", :name => "custom_name", :tabindex => 70) %>
+        EOTEMPLATE
+    end
+
     let :datepicker_input_tf_and_dp_options_template do
         <<-EOTEMPLATE
           <%= datepicker_input(:foo, :att1, :dateFormat  => "yy-mm-dd", :minDate => -20, :maxDate => "+1M +10D", :tabindex => 70) %>
@@ -66,7 +76,7 @@ describe JqueryDatepicker do
     
     let :datepicker_input_dateFormat_template do
         <<-EOTEMPLATE
-          <%= datepicker_input(:foo, :att1, :dateFormat  => "yy-mm-dd", :minDate => -20, :maxDate => "+1M +10D", :value => "#{current_value.utc.to_s}") %>
+          <%= datepicker_input(:foo, :att1, :dateFormat  => "yy-mm-dd", :minDate => -20, :maxDate => "+1M +10D", :value => "#{current_value.to_s}") %>
         EOTEMPLATE
     end
     
@@ -90,7 +100,7 @@ describe JqueryDatepicker do
 
     let :datepicker_input_with_value_template do
         <<-EOTEMPLATE
-          <%= datepicker_input(:foo, :att1, :value => "#{current_value.utc.to_s}") %>
+          <%= datepicker_input(:foo, :att1, :value => "#{current_value.to_s}") %>
         EOTEMPLATE
     end
     
@@ -103,7 +113,11 @@ describe JqueryDatepicker do
     let :valid_response_javascript_with_options do
       "<script type=\"text/javascript\">\n//<![CDATA[\njQuery(document).ready(function(){jQuery('#foo_att1').datepicker({\"dateFormat\":\"yy-mm-dd\",\"maxDate\":\"+1M +10D\",\"minDate\":-20})});\n//]]>\n</script>"
     end
-    
+ 
+    let :valid_response_javascript_with_options_id_and_name do
+      "<script type=\"text/javascript\">\n//<![CDATA[\njQuery(document).ready(function(){jQuery('#custom_id').datepicker({\"dateFormat\":\"yy-mm-dd\",\"maxDate\":\"+1M +10D\",\"minDate\":-20})});\n//]]>\n</script>"
+    end
+
     let :valid_response_javascript_with_options_M do
       "<script type=\"text/javascript\">\n//<![CDATA[\njQuery(document).ready(function(){jQuery('#foo_att1').datepicker({\"dateFormat\":\"dd M yy\",\"maxDate\":\"+1M +10D\",\"minDate\":-20})});\n//]]>\n</script>"
     end
@@ -115,13 +129,17 @@ describe JqueryDatepicker do
     let :valid_response_input_with_options do
       "<input id=\"foo_att1\" name=\"foo[att1]\" size=\"30\" tabindex=\"70\" type=\"text\" />"
     end
+
+    let :valid_response_input_with_options_id_and_name do
+      "<input id=\"custom_id\" name=\"custom_name\" size=\"30\" tabindex=\"70\" type=\"text\" />"
+    end
     
     let :valid_response_input_with_options_empty do
       "<input id=\"foo_att1\" name=\"foo[att1]\" size=\"30\" tabindex=\"70\" type=\"text\" value=\"\" />"
     end
     
     let :valid_response_input_with_value do
-      "<input id=\"foo_att1\" name=\"foo[att1]\" size=\"30\" type=\"text\" value=\"#{current_value.utc.to_s}\" />"
+      "<input id=\"foo_att1\" name=\"foo[att1]\" size=\"30\" type=\"text\" value=\"#{current_value.to_s}\" />"
     end
     
     let :valid_response_input_with_value_formatted do
@@ -150,7 +168,12 @@ describe JqueryDatepicker do
       render :inline => datepicker_input_tf_options_template
       rendered.strip.should == valid_response_input_with_options+valid_response_javascript
     end
-    
+
+    it "should use the text_field options id and name" do
+      render :inline => datepicker_input_tf_options_id_and_name_template
+      rendered.strip.should == valid_response_input_with_options_id_and_name+valid_response_javascript_with_tf_options
+    end
+
     it "should use populate the default value when sending a Date.to_s" do
       render :inline => datepicker_input_dateFormat_template_date
       rendered.strip.should == valid_response_input_with_value_formatted+valid_response_javascript_with_options

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'active_support/deprecation'
 require 'action_view'
 require 'rspec/rails/adapters'
 require 'rspec/rails/example/rails_example_group'
-require 'rspec/rails/matchers/render_template'
+require 'rspec/rails/matchers'
 require 'rspec/rails/example/view_example_group'
 require 'rspec/rails/mocks'
 


### PR DESCRIPTION
Makes this work properly:

```
= f.datepicker :date, id: "custom_id"
```

Before this you would get:

```
jQuery(document).ready(function(){jQuery('#model_name_date').datepicker({})});
```

Instead of:

```
jQuery(document).ready(function(){jQuery('#custom_id').datepicker({})});
```

There's also a call to stringify_keys in there for supporting symbols, so that both of these work:

```
= f.datepicker :date, id: "custom_id"
= f.datepicker :date, "id" => "custom_id"
```
