### PR TITLE
Fix #35 ('jQuery is not defined' when jquery_datepicker HTML output exists in the DOM before jQuery gets loaded.)

### DIFF
--- a/lib/app/helpers/form_helper.rb
+++ b/lib/app/helpers/form_helper.rb
@@ -12,7 +12,7 @@ module JqueryDatepicker
       tf_options[:value] = input_tag.format_date(tf_options[:value], String.new(dp_options[:dateFormat])) if  tf_options[:value] && !tf_options[:value].empty? && dp_options.has_key?(:dateFormat)
       html = input_tag.to_input_field_tag("text", tf_options)
       method = timepicker ? "datetimepicker" : "datepicker"
-      html += javascript_tag("jQuery(document).ready(function(){jQuery('##{input_tag.get_name_and_id["id"]}').#{method}(#{dp_options.to_json})});")
+      html += javascript_tag("jQuery(document).ready(function(){jQuery('##{input_tag.get_name_and_id["id"]}').#{method}(#{dp_options.to_json})});", :defer => 'defer')
       html.html_safe
     end
     

--- a/lib/app/helpers/form_helper.rb
+++ b/lib/app/helpers/form_helper.rb
@@ -12,7 +12,7 @@ module JqueryDatepicker
       tf_options[:value] = input_tag.format_date(tf_options[:value], String.new(dp_options[:dateFormat])) if  tf_options[:value] && !tf_options[:value].empty? && dp_options.has_key?(:dateFormat)
       html = input_tag.to_input_field_tag("text", tf_options)
       method = timepicker ? "datetimepicker" : "datepicker"
-      html += javascript_tag("jQuery(document).ready(function(){jQuery('##{input_tag.get_name_and_id["id"]}').#{method}(#{dp_options.to_json})});", :defer => 'defer')
+      html += javascript_tag("window.onload = function() { jQuery(document).ready(function(){jQuery('##{input_tag.get_name_and_id["id"]}').#{method}(#{dp_options.to_json})}); }")
       html.html_safe
     end
     


### PR DESCRIPTION
Fix issue with loading datepicker, when jQuery included at bottom of page (before `</body>`).
